### PR TITLE
fix: tools-2772 validate logging context drv-mem

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -1009,7 +1009,7 @@ var validateTests = []validateTest{
 		expectedResult: `context: (root).namespaces.0
 	- description: Additional property memory-size is not allowed, error-type: additional_property_not_allowed
 context: (root).namespaces.0.storage-engine
-	- description: data-size is required, error-type: required
+	- description: devices is required, error-type: required
 context: (root).namespaces.1
 	- description: Additional property memory-size is not allowed, error-type: additional_property_not_allowed
 context: (root).namespaces.1.index-type
@@ -1021,7 +1021,7 @@ context: (root).namespaces.1.sindex-type
 	- description: Additional property mounts-size-limit is not allowed, error-type: additional_property_not_allowed
 	- description: mounts-budget is required, error-type: required
 context: (root).namespaces.1.storage-engine
-	- description: data-size is required, error-type: required
+	- description: devices is required, error-type: required
 context: (root).service
 	- description: cluster-name is required, error-type: required
 `,

--- a/testdata/cases/server70/server70.conf
+++ b/testdata/cases/server70/server70.conf
@@ -21,6 +21,10 @@ logging {
 	file /dummy/file/path2 {
 		context any info
 	}
+
+	console {
+		context drv-mem debug
+	}
 }
 
 network {

--- a/testdata/cases/server70/server70.yaml
+++ b/testdata/cases/server70/server70.yaml
@@ -1,4 +1,6 @@
 logging:
+    - drv-mem: debug
+      name: console
     - any: info
       name: /dummy/file/path2
 namespaces:


### PR DESCRIPTION
Use the operator team's server 7.0 schema which includes the drv-mem logging context. Without this, configs including "drv-mem" logging contexts will fail validation.