### PR TITLE
tools-2692 fix force flag when version not supplied in -a or file metadata

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -110,7 +110,7 @@ func newConvertCmd() *cobra.Command {
 			// try populating from the metadata
 			if version == "" {
 				version, err = getMetaDataItem(fdata, metaKeyAerospikeVersion)
-				if err != nil {
+				if err != nil && !force {
 					return errors.Join(errMissingAerospikeVersion, err)
 				}
 			}


### PR DESCRIPTION
fixes an unreleased bug where --force is ignored when Aerospike server version is not supplied in -a or config file metadata