### PR TITLE
fix: tools-2875 display all errors generated while using the validati…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,10 @@ ifdef GOARCH
 GO_ENV_VARS += GOARCH=$(GOARCH)
 endif
 
+SOURCES := $(shell find . -name "*.go")
+
 # Builds asconfig binary
-$(ACONFIG_BIN): $(wildcard *.go)
+$(ACONFIG_BIN): $(SOURCES)
 	$(GO_ENV_VARS) go build -ldflags="-X 'github.com/aerospike/asconfig/cmd.VERSION=$(VERSION)'" -o $(ACONFIG_BIN) .
 
 # Clean up

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -91,14 +91,13 @@ func newValidateCmd() *cobra.Command {
 			}
 
 			verrs, err := conf.NewConfigValidator(asconfig, mgmtLibLogger, version).Validate()
-			if verrs != nil {
+			// verrs is an empty slice if err is not nil but no
+			// validation errors were found
+			if len(verrs.Errors) > 0 {
 				// force validation errors to be written to stdout
 				// so they can more easily be grepd etc.
 				cmd.Print(verrs.Error())
 				return errors.Join(conf.ErrConfigValidation, ErrSilent)
-			}
-			if err != nil {
-				return err
 			}
 
 			return err

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -93,7 +93,7 @@ func newValidateCmd() *cobra.Command {
 			verrs, err := conf.NewConfigValidator(asconfig, mgmtLibLogger, version).Validate()
 			// verrs is an empty slice if err is not nil but no
 			// validation errors were found
-			if len(verrs.Errors) > 0 {
+			if verrs != nil && len(verrs.Errors) > 0 {
 				// force validation errors to be written to stdout
 				// so they can more easily be grepd etc.
 				cmd.Print(verrs.Error())


### PR DESCRIPTION
…on command

Using a similar example to the ticket, validating unsupported Aerospike versions now displays an error.

```shell
./bin/asconfig validate -a 7.2.0 testdata/cases/server70/server70.conf
INFO[2024-03-27T09:34:25-07:00] Using config file: /etc/aerospike/astools.conf 
ERRO[2024-03-27T09:34:25-07:00] error while validating config                
ERRO[2024-03-27T09:34:25-07:00] failed to get aerospike config schema for version 7.2.0: unsupported version 
```