### PR TITLE
fix: TOOLS-2979 logging levels to have case insensitive compare

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -162,6 +162,11 @@ func diffFlatMaps(m1 map[string]any, m2 map[string]any) []string {
 			continue
 		}
 
+		// #TOOLS-2979 if part of logging section and is valid logging enum when compared "info" == "INFO"
+		if strings.HasPrefix(k, "logging.") && isValidLoggingEnumCompare(v1, v2) {
+			continue
+		}
+
 		if !reflect.DeepEqual(v1, v2) {
 			res = append(res, fmt.Sprintf("%s:\n\t<: %v\n\t>: %v\n", k, v1, v2))
 		}

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -59,6 +59,11 @@ var testDiffArgs = []runTestDiff{
 		expectError: false,
 	},
 	{
+		flags:       []string{"--log-level", "debug"},
+		arguments:   []string{"../testdata/expected/all_flash_cluster_cr.conf", "../testdata/expected/all_flash_cluster_cr_info_cap.conf"},
+		expectError: false,
+	},
+	{
 		flags:       []string{"--format", "bad_fmt"},
 		arguments:   []string{},
 		expectError: true,
@@ -67,11 +72,6 @@ var testDiffArgs = []runTestDiff{
 		flags:       []string{"-F", "bad_fmt"},
 		arguments:   []string{},
 		expectError: true,
-	},
-	{
-		flags:       []string{"--log-level", "debug"},
-		arguments:   []string{"../testdata/expected/all_flash_cluster_cr.conf", "../testdata/expected/all_flash_cluster_cr_info_cap.conf"},
-		expectError: false,
 	},
 }
 

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -68,6 +68,11 @@ var testDiffArgs = []runTestDiff{
 		arguments:   []string{},
 		expectError: true,
 	},
+	{
+		flags:       []string{"--log-level", "debug"},
+		arguments:   []string{"../testdata/expected/all_flash_cluster_cr.conf", "../testdata/expected/all_flash_cluster_cr_info_cap.conf"},
+		expectError: false,
+	},
 }
 
 func TestRunEDiff(t *testing.T) {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -34,33 +34,27 @@ type metaDataArgs struct {
 	asconfigVersion  string
 }
 
+// isValidLoggingEnumCompare compares two values to determine if they are valid logging levels and if they are equal.
+// It first converts the values to strings, then to lower case, and checks if they are valid logging levels.
+// If both values are valid logging levels and are equal, it returns true; otherwise, it returns false.
+//
+// Parameters:
+//   - s1: The first value to compare, of any type.
+//   - s2: The second value to compare, of any type.
+//
+// Returns:
+//   - bool: True if both values are valid logging levels and are equal, false otherwise.
 func isValidLoggingEnumCompare(s1 any, s2 any) bool {
-	// convert to string
-	str1, ok := toString(s1)
-	if !ok {
+	str1, ok1 := toString(s1)
+	str2, ok2 := toString(s2)
+	if !ok1 || !ok2 {
 		return false
 	}
-	str2, ok := toString(s2)
-	if !ok {
-		return false
-	}
-	// convert to lower case
+
 	str1Lower := strings.ToLower(str1)
 	str2Lower := strings.ToLower(str2)
 
-	// check if the strings are valid logging levels
-	if _, ok := LoggingEnum[str1Lower]; !ok {
-		return false
-	}
-	if _, ok := LoggingEnum[str2Lower]; !ok {
-		return false
-	}
-
-	// compare the strings
-	if str1Lower == str2Lower {
-		return true
-	}
-	return false
+	return str1Lower == str2Lower && LoggingEnum[str1Lower]
 }
 
 func toString(value interface{}) (string, bool) {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -19,10 +19,53 @@ const (
 	metaKeyAsadmVersion     = "asadm-version"
 )
 
+// LoggingEnum is a map of valid logging levels - collated from schema
+var LoggingEnum = map[string]bool{
+	"critical": true,
+	"warning":  true,
+	"info":     true,
+	"debug":    true,
+	"detail":   true,
+}
+
 type metaDataArgs struct {
 	src              []byte
 	aerospikeVersion string
 	asconfigVersion  string
+}
+
+func isValidLoggingEnumCompare(s1 any, s2 any) bool {
+	// convert to string
+	str1, ok := toString(s1)
+	if !ok {
+		return false
+	}
+	str2, ok := toString(s2)
+	if !ok {
+		return false
+	}
+	// convert to lower case
+	str1Lower := strings.ToLower(str1)
+	str2Lower := strings.ToLower(str2)
+
+	// check if the strings are valid logging levels
+	if _, ok := LoggingEnum[str1Lower]; !ok {
+		return false
+	}
+	if _, ok := LoggingEnum[str2Lower]; !ok {
+		return false
+	}
+
+	// compare the strings
+	if str1Lower == str2Lower {
+		return true
+	}
+	return false
+}
+
+func toString(value interface{}) (string, bool) {
+	str, ok := value.(string)
+	return str, ok
 }
 
 func genMetaDataText(src []byte, msg []byte, mdata map[string]string) ([]byte, error) {

--- a/testdata/cases/server71/conf-tests.json
+++ b/testdata/cases/server71/conf-tests.json
@@ -6,7 +6,6 @@
         "Arguments":["convert","--aerospike-version","7.1.0.0","--format","asconfig","--output","testdata/cases/server71/server71-res-.yaml"],
         "SkipServerTest":false,
         "ServerErrorAllowList":null,
-        "ServerImage":"aerospike.jfrog.io/docker-remote/aerospike/aerospike-server-enterprise-rc:7.1.0.0-rc3",
-        "DockerAuth":{"Username":"ASC_DOCKER_USER","Password":"ASC_DOCKER_PASS"}
+        "ServerImage":"aerospike/aerospike-server-enterprise:7.1.0.7"
     }
 ]

--- a/testdata/cases/server71/yaml-tests.json
+++ b/testdata/cases/server71/yaml-tests.json
@@ -6,7 +6,6 @@
         "Arguments":["convert","--aerospike-version","7.1.0.0","--format","yaml","--output","testdata/cases/server71/server71-res-.conf"],
         "SkipServerTest":false,
         "ServerErrorAllowList":null,
-        "ServerImage":"aerospike.jfrog.io/docker-remote/aerospike/aerospike-server-enterprise-rc:7.1.0.0-rc3",
-        "DockerAuth":{"Username":"ASC_DOCKER_USER","Password":"ASC_DOCKER_PASS"}
+        "ServerImage":"aerospike/aerospike-server-enterprise:7.1.0.7"
     }
 ]

--- a/testdata/cases/server72/conf-tests.json
+++ b/testdata/cases/server72/conf-tests.json
@@ -6,7 +6,6 @@
         "Arguments":["convert","--aerospike-version","7.2.0.0","--format","asconfig","--output","testdata/cases/server72/server72-res-.yaml"],
         "SkipServerTest":false,
         "ServerErrorAllowList":null,
-        "ServerImage":"aerospike.jfrog.io/docker-remote/aerospike/aerospike-server-enterprise-rc:7.2.0.0-rc3",
-        "DockerAuth":{"Username":"ASC_DOCKER_USER","Password":"ASC_DOCKER_PASS"}
+        "ServerImage":"aerospike/aerospike-server-enterprise:7.2.0.1_2"
     }
 ]

--- a/testdata/cases/server72/yaml-tests.json
+++ b/testdata/cases/server72/yaml-tests.json
@@ -6,7 +6,6 @@
         "Arguments":["convert","--aerospike-version","7.2.0.0","--format","yaml","--output","testdata/cases/server72/server72-res-.conf"],
         "SkipServerTest":false,
         "ServerErrorAllowList":null,
-        "ServerImage":"aerospike.jfrog.io/docker-remote/aerospike/aerospike-server-enterprise-rc:7.2.0.0-rc3",
-        "DockerAuth":{"Username":"ASC_DOCKER_USER","Password":"ASC_DOCKER_PASS"}
+        "ServerImage":"aerospike/aerospike-server-enterprise:7.2.0.1_2"
     }
 ]

--- a/testdata/expected/all_flash_cluster_cr_info_cap.conf
+++ b/testdata/expected/all_flash_cluster_cr_info_cap.conf
@@ -1,0 +1,44 @@
+
+logging {
+
+    console {
+        context any    INFO
+    }
+}
+
+namespace test {
+    memory-size    3000000000
+    replication-factor    2
+
+    index-type flash {
+        mount    /test/dev/xvdf-index
+        mounts-size-limit    4294967296
+    }
+
+    storage-engine device {
+        device    /test/dev/xvdf
+    }
+}
+
+network {
+
+    fabric {
+        port    3001
+    }
+
+    heartbeat {
+        mode    mesh
+        port    3002
+    }
+
+    service {
+        port    3000
+    }
+}
+
+security {
+}
+
+service {
+    feature-key-file    /etc/aerospike/secret/features.conf
+}


### PR DESCRIPTION
Logging levels have values

from schema
```
["CRITICAL", "critical", "WARNING", "warning", "INFO", "info", "DEBUG", "debug", "DETAIL", "detail"]
```

on running asconfig diff, they should have case-insensitive comparison