### PR TITLE
fix: deprecate macos-12 from github actions

### DIFF
--- a/.github/workflows/mac-artifact.yml
+++ b/.github/workflows/mac-artifact.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     strategy:
       matrix: 
-        os: [macos-12, macos-14]
+        os: [macos-13, macos-14, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Get checkout directory


### PR DESCRIPTION
macos-12 getting deprecated from GitHub-actions