### PR TITLE
fix: handle max-record-size config with unit suffixes like M and K tools-3074

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.8
 
 require (
 	github.com/aerospike/aerospike-client-go/v8 v8.2.1
-	github.com/aerospike/aerospike-management-lib v1.7.1-0.20250519063642-57d55e3eddf8
+	github.com/aerospike/aerospike-management-lib v1.7.1-0.20250701224118-bcdcb7f3e5c1
 	github.com/aerospike/tools-common-go v0.2.1-0.20250130070321-acda09110e14
 	github.com/bombsimon/logrusr/v4 v4.1.0
 	github.com/docker/docker v27.5.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,12 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/aerospike/aerospike-client-go/v8 v8.2.1 h1:Vxp+E1Sj+r5o67x+BP8FE07DVwo7x1AHWzfnQU1wzIU=
 github.com/aerospike/aerospike-client-go/v8 v8.2.1/go.mod h1:H6CzKDoHxBj1yY/oQPci1bUIbEx2ATQtJ2GtZ+N64Wg=
+github.com/aerospike/aerospike-management-lib v1.4.1-0.20250701223323-cb1a9f0921cb h1:+lHRAAxQFJ9GHOpCQLxamssnPWIHmbfKJeAAKbZI6kE=
+github.com/aerospike/aerospike-management-lib v1.4.1-0.20250701223323-cb1a9f0921cb/go.mod h1:3JKrmC/mLSV8SygbrPQPNV8T7bFaTMjB8wfnX25gB+4=
 github.com/aerospike/aerospike-management-lib v1.7.1-0.20250519063642-57d55e3eddf8 h1:wNMqJ+Xdn3+UiY4t4gC5wISNrT1v5cE3GmneFrKI5XQ=
 github.com/aerospike/aerospike-management-lib v1.7.1-0.20250519063642-57d55e3eddf8/go.mod h1:lQggqSKESePgU+FmSRSBUCPcQdeiYS/RreMcHWXMWlU=
+github.com/aerospike/aerospike-management-lib v1.7.1-0.20250701224118-bcdcb7f3e5c1 h1:RKypEzR1L/cEazx3x2a7ExjfY/rFKRBeV1DI6vJH4yk=
+github.com/aerospike/aerospike-management-lib v1.7.1-0.20250701224118-bcdcb7f3e5c1/go.mod h1:lQggqSKESePgU+FmSRSBUCPcQdeiYS/RreMcHWXMWlU=
 github.com/aerospike/tools-common-go v0.2.1-0.20250130070321-acda09110e14 h1:rHS7ABctGIJEw+vxtHNDdKxxYo6iF3BCMD4XDIvQzOo=
 github.com/aerospike/tools-common-go v0.2.1-0.20250130070321-acda09110e14/go.mod h1:sAbVIRJS7Wn9UY7DwI59wDfRjOZUAcR6sACLCSNYWgc=
 github.com/bombsimon/logrusr/v4 v4.1.0 h1:uZNPbwusB0eUXlO8hIUwStE6Lr5bLN6IgYgG+75kuh4=

--- a/testdata/cases/server72/server72.conf
+++ b/testdata/cases/server72/server72.conf
@@ -66,6 +66,8 @@ namespace ns1 {
 	}
 
 	active-rack 2
+
+	max-record-size 1M
 }
 
 namespace ns2 {

--- a/testdata/cases/server72/server72.yaml
+++ b/testdata/cases/server72/server72.yaml
@@ -5,6 +5,7 @@ namespaces:
     - default-read-touch-ttl-pct: 0
       index-type:
         type: shmem
+      max-record-size: 1048576
       name: ns2
       replication-factor: 2
       sets:


### PR DESCRIPTION
See the ticket for details. This updates asconfig to the management lib branch that can handle max-record-size with a units suffix and adds a regression test.