### PR TITLE
feat: TOOLS-3092 Add schema diff and list-schemas commands

### DIFF
--- a/cmd/list_schemas.go
+++ b/cmd/list_schemas.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/aerospike/asconfig/schema"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(listSchemasCmd)
+}
+
+var listSchemasCmd = newListSchemasCmd()
+
+func newListSchemasCmd() *cobra.Command {
+	res := &cobra.Command{
+		Use:     "list-schemas",
+		Short:   "List available Aerospike schema versions.",
+		Long:    `List all available Aerospike schema versions that can be used with the schema-diff command.`,
+		Example: `  asconfig list-schemas`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			logger.Debug("Running list-schemas command")
+
+			// Load schema map
+			schemaMap, err := schema.NewSchemaMap()
+			if err != nil {
+				return fmt.Errorf("failed to load schema map: %w", err)
+			}
+
+			// Get all version keys (exclude README)
+			var versions []string
+			for version := range schemaMap {
+				if !strings.Contains(strings.ToLower(version), "readme") {
+					versions = append(versions, version)
+				}
+			}
+
+			// Sort versions
+			sort.Strings(versions)
+
+			// Get output format
+			format, _ := cmd.Flags().GetString("format")
+
+			// Display versions
+			if format == "table" {
+				cmd.Printf("Available Aerospike Schema Versions:\n")
+				cmd.Printf("====================================\n")
+				for i, version := range versions {
+					cmd.Printf("%2d. %s\n", i+1, version)
+				}
+				cmd.Printf("\nTotal: %d versions\n", len(versions))
+			} else {
+				// Simple format (default)
+				cmd.Println(strings.Join(versions, "\n"))
+			}
+
+			return nil
+		},
+	}
+
+	res.Flags().StringP("format", "f", "simple", "Output format: 'simple' (space-separated) or 'table' (numbered list)")
+
+	return res
+}

--- a/cmd/list_schemas_test.go
+++ b/cmd/list_schemas_test.go
@@ -1,0 +1,95 @@
+//go:build unit
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestListSchemasCmd(t *testing.T) {
+	testCases := []struct {
+		name        string
+		flags       map[string]string
+		expectError bool
+		checkOutput func(string) bool
+	}{
+		{
+			name:        "simple format",
+			flags:       map[string]string{},
+			expectError: false,
+			checkOutput: func(output string) bool {
+				// Simple format should have versions separated by spaces
+				return strings.Contains(output, "6.4.0") && strings.Contains(output, "7.0.0")
+			},
+		},
+		{
+			name:        "table format",
+			flags:       map[string]string{"format": "table"},
+			expectError: false,
+			checkOutput: func(output string) bool {
+				// Table format should contain headers and numbered list
+				return strings.Contains(output, "Available Aerospike Schema Versions:") &&
+					strings.Contains(output, "Total:") &&
+					strings.Contains(output, "6.4.0") &&
+					strings.Contains(output, "7.0.0")
+			},
+		},
+		{
+			name:        "invalid format",
+			flags:       map[string]string{"format": "invalid"},
+			expectError: false, // Command should still run but use default behavior
+			checkOutput: func(output string) bool {
+				// Should default to simple format
+				return strings.Contains(output, "6.4.0") && strings.Contains(output, "7.0.0")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newListSchemasCmd()
+
+			// Set flags
+			for key, value := range tc.flags {
+				cmd.Flags().Set(key, value)
+			}
+
+			// Capture output
+			var output strings.Builder
+			cmd.SetOut(&output)
+			cmd.SetErr(&output)
+
+			// Execute command
+			err := cmd.RunE(cmd, []string{})
+
+			if tc.expectError && err == nil {
+				t.Errorf("Expected error but got none")
+			} else if !tc.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+
+			if tc.checkOutput != nil && !tc.checkOutput(output.String()) {
+				t.Errorf("Output check failed. Output: %s", output.String())
+			}
+		})
+	}
+}
+
+func TestListSchemasDoesNotIncludeReadme(t *testing.T) {
+	cmd := newListSchemasCmd()
+
+	var output strings.Builder
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+
+	err := cmd.RunE(cmd, []string{})
+	if err != nil {
+		t.Errorf("Command failed: %v", err)
+	}
+
+	outputStr := output.String()
+	if strings.Contains(strings.ToLower(outputStr), "readme") {
+		t.Errorf("Output should not contain README files, but got: %s", outputStr)
+	}
+}

--- a/cmd/schema_diff.go
+++ b/cmd/schema_diff.go
@@ -1,0 +1,360 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	asConf "github.com/aerospike/aerospike-management-lib/asconfig"
+	"github.com/aerospike/asconfig/schema"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	schemaDiffArgMin = 2
+	schemaDiffArgMax = 2
+)
+
+var (
+	errSchemaDiffTooFewArgs  = fmt.Errorf("schema-diff requires at least %d version arguments", schemaDiffArgMin)
+	errSchemaDiffTooManyArgs = fmt.Errorf("schema-diff requires no more than %d version arguments", schemaDiffArgMax)
+	errInvalidSchemaVersion  = fmt.Errorf("invalid schema version")
+)
+
+func init() {
+	rootCmd.AddCommand(schemaDiffCmd)
+}
+
+var schemaDiffCmd = newSchemaDiffCmd()
+
+func newSchemaDiffCmd() *cobra.Command {
+	res := &cobra.Command{
+		Use:   "schema-diff [flags] <version1> <version2>",
+		Short: "Compare Aerospike configuration schemas between two versions.",
+		Long: `Schema-diff compares the configuration schemas between two Aerospike versions,
+				showing which configuration parameters are added, removed, or changed.
+				This helps understand what configuration options are going away or
+				staying when upgrading between Aerospike versions.
+				
+				Examples:
+				  asconfig schema-diff 6.4.0 7.0.0
+				  asconfig schema-diff 5.7.0 6.4.0 --verbose`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			logger.Debug("Running schema-diff command")
+
+			if len(args) < schemaDiffArgMin {
+				return errSchemaDiffTooFewArgs
+			}
+
+			if len(args) > schemaDiffArgMax {
+				return errSchemaDiffTooManyArgs
+			}
+
+			version1 := args[0]
+			version2 := args[1]
+
+			logger.Debugf("Comparing schema from version %s to version %s", version1, version2)
+
+			// Validate versions are supported
+			supported1, err := asConf.IsSupportedVersion(version1)
+			if err != nil {
+				return errors.Join(errInvalidSchemaVersion, fmt.Errorf("version %s: %w", version1, err))
+			}
+			if !supported1 {
+				return fmt.Errorf("version %s is not supported", version1)
+			}
+
+			supported2, err := asConf.IsSupportedVersion(version2)
+			if err != nil {
+				return errors.Join(errInvalidSchemaVersion, fmt.Errorf("version %s: %w", version2, err))
+			}
+			if !supported2 {
+				return fmt.Errorf("version %s is not supported", version2)
+			}
+
+			// Load schemas
+			schemaMap, err := schema.NewSchemaMap()
+			if err != nil {
+				return fmt.Errorf("failed to load schema map: %w", err)
+			}
+
+			schema1, exists := schemaMap[version1]
+			if !exists {
+				return fmt.Errorf("schema for version %s not found", version1)
+			}
+
+			schema2, exists := schemaMap[version2]
+			if !exists {
+				return fmt.Errorf("schema for version %s not found", version2)
+			}
+
+			// Parse schemas
+			var parsedSchema1, parsedSchema2 map[string]interface{}
+			if err := json.Unmarshal([]byte(schema1), &parsedSchema1); err != nil {
+				return fmt.Errorf("failed to parse schema for version %s: %w", version1, err)
+			}
+
+			if err := json.Unmarshal([]byte(schema2), &parsedSchema2); err != nil {
+				return fmt.Errorf("failed to parse schema for version %s: %w", version2, err)
+			}
+
+			// Extract configuration properties
+			props1 := extractConfigProperties(parsedSchema1)
+			props2 := extractConfigProperties(parsedSchema2)
+
+			// Get flags
+			verbose, _ := cmd.Flags().GetBool("verbose")
+			showDeprecated, _ := cmd.Flags().GetBool("show-deprecated")
+			filterPath, _ := cmd.Flags().GetString("filter-path")
+
+			// Compare schemas
+			diffs := compareSchemasDetailed(props1, props2, verbose, showDeprecated, filterPath)
+
+			// Output results
+			if len(diffs) == 0 {
+				fmt.Printf("No differences found between schema versions %s and %s\n", version1, version2)
+				return nil
+			}
+
+			fmt.Printf("Schema differences from version %s to version %s:\n", version1, version2)
+			fmt.Printf("Legend: '+' = added, '-' = removed, '~' = changed\n\n")
+
+			for _, diff := range diffs {
+				fmt.Print(diff)
+			}
+
+			return nil
+		},
+	}
+
+	res.Flags().BoolP("verbose", "v", false, "Show detailed information about property changes (type, default values, etc.)")
+	res.Flags().BoolP("show-deprecated", "D", false, "Show deprecated properties")
+	res.Flags().StringP("filter-path", "f", "", "Filter results to only show properties under the specified path (e.g., 'service', 'namespaces')")
+
+	return res
+}
+
+// extractConfigProperties recursively extracts all configuration properties from a schema
+func extractConfigProperties(schema map[string]interface{}) map[string]PropertyInfo {
+	properties := make(map[string]PropertyInfo)
+
+	if props, ok := schema["properties"].(map[string]interface{}); ok {
+		extractPropertiesRecursive(props, "", properties)
+	}
+
+	return properties
+}
+
+// PropertyInfo holds information about a schema property
+type PropertyInfo struct {
+	Type           string
+	Default        interface{}
+	Description    string
+	Dynamic        bool
+	EnterpriseOnly bool
+	Enum           []interface{}
+	Minimum        interface{}
+	Maximum        interface{}
+	Required       bool
+	Deprecated     bool
+}
+
+// extractPropertiesRecursive recursively extracts properties from nested objects
+func extractPropertiesRecursive(props map[string]interface{}, prefix string, result map[string]PropertyInfo) {
+	for key, value := range props {
+		fullKey := key
+		if prefix != "" {
+			fullKey = prefix + "." + key
+		}
+
+		if propMap, ok := value.(map[string]interface{}); ok {
+			info := PropertyInfo{}
+
+			// Extract basic properties
+			if t, ok := propMap["type"].(string); ok {
+				info.Type = t
+			}
+			if def, ok := propMap["default"]; ok {
+				info.Default = def
+			}
+			if desc, ok := propMap["description"].(string); ok {
+				info.Description = desc
+			}
+			if dyn, ok := propMap["dynamic"].(bool); ok {
+				info.Dynamic = dyn
+			}
+			if ent, ok := propMap["enterpriseOnly"].(bool); ok {
+				info.EnterpriseOnly = ent
+			}
+			if dep, ok := propMap["deprecated"].(bool); ok {
+				info.Deprecated = dep
+			}
+			if enum, ok := propMap["enum"].([]interface{}); ok {
+				info.Enum = enum
+			}
+			if min, ok := propMap["minimum"]; ok {
+				info.Minimum = min
+			}
+			if max, ok := propMap["maximum"]; ok {
+				info.Maximum = max
+			}
+
+			result[fullKey] = info
+
+			// Recursively process nested properties
+			if nestedProps, ok := propMap["properties"].(map[string]interface{}); ok {
+				extractPropertiesRecursive(nestedProps, fullKey, result)
+			}
+
+			// Handle array items - for cases like namespaces which are arrays
+			if items, ok := propMap["items"].(map[string]interface{}); ok {
+				itemsKey := fullKey + ".items"
+				extractPropertiesRecursive(map[string]interface{}{"items": items}, fullKey, result)
+
+				// If items has properties, process them
+				if itemProps, ok := items["properties"].(map[string]interface{}); ok {
+					extractPropertiesRecursive(itemProps, itemsKey, result)
+				}
+			}
+
+			// Handle oneOf arrays
+			if oneOf, ok := propMap["oneOf"].([]interface{}); ok {
+				for i, oneOfItem := range oneOf {
+					if oneOfMap, ok := oneOfItem.(map[string]interface{}); ok {
+						oneOfKey := fmt.Sprintf("%s.oneOf.%d", fullKey, i)
+						extractPropertiesRecursive(map[string]interface{}{fmt.Sprintf("%d", i): oneOfMap}, fullKey+".oneOf", result)
+
+						// If oneOf item has properties, process them
+						if oneOfProps, ok := oneOfMap["properties"].(map[string]interface{}); ok {
+							extractPropertiesRecursive(oneOfProps, oneOfKey, result)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// compareSchemasDetailed compares two sets of schema properties and returns detailed differences
+func compareSchemasDetailed(props1, props2 map[string]PropertyInfo, showDetails, showDeprecated bool, filterPath string) []string {
+	var diffs []string
+
+	// Get all unique keys
+	allKeys := make(map[string]struct{})
+	for k := range props1 {
+		if filterPath == "" || strings.HasPrefix(k, filterPath) {
+			allKeys[k] = struct{}{}
+		}
+	}
+	for k := range props2 {
+		if filterPath == "" || strings.HasPrefix(k, filterPath) {
+			allKeys[k] = struct{}{}
+		}
+	}
+
+	// Sort keys for consistent output
+	var sortedKeys []string
+	for k := range allKeys {
+		sortedKeys = append(sortedKeys, k)
+	}
+	sort.Strings(sortedKeys)
+
+	// Track counts for summary
+	var added, removed, changed int
+
+	for _, key := range sortedKeys {
+		prop1, exists1 := props1[key]
+		prop2, exists2 := props2[key]
+
+		if !exists1 && exists2 {
+			// Property was added
+			added++
+			if !showDeprecated && prop2.Deprecated {
+				continue
+			}
+
+			diff := fmt.Sprintf("+ %s", key)
+			if showDetails {
+				diff += fmt.Sprintf(" (type: %s", prop2.Type)
+				if prop2.Default != nil {
+					diff += fmt.Sprintf(", default: %v", prop2.Default)
+				}
+				if prop2.EnterpriseOnly {
+					diff += ", enterprise-only"
+				}
+				if prop2.Deprecated {
+					diff += ", deprecated"
+				}
+				diff += ")"
+			}
+			diffs = append(diffs, diff+"\n")
+
+		} else if exists1 && !exists2 {
+			// Property was removed
+			removed++
+			if !showDeprecated && prop1.Deprecated {
+				continue
+			}
+
+			diff := fmt.Sprintf("- %s", key)
+			if showDetails {
+				diff += fmt.Sprintf(" (was type: %s", prop1.Type)
+				if prop1.Default != nil {
+					diff += fmt.Sprintf(", default: %v", prop1.Default)
+				}
+				if prop1.EnterpriseOnly {
+					diff += ", enterprise-only"
+				}
+				if prop1.Deprecated {
+					diff += ", deprecated"
+				}
+				diff += ")"
+			}
+			diffs = append(diffs, diff+"\n")
+
+		} else if exists1 && exists2 {
+			// Property exists in both, check for changes
+			if !reflect.DeepEqual(prop1, prop2) {
+				changed++
+				if !showDeprecated && (prop1.Deprecated || prop2.Deprecated) {
+					continue
+				}
+
+				diff := fmt.Sprintf("~ %s", key)
+				if showDetails {
+					var changes []string
+					if prop1.Type != prop2.Type {
+						changes = append(changes, fmt.Sprintf("type: %s → %s", prop1.Type, prop2.Type))
+					}
+					if !reflect.DeepEqual(prop1.Default, prop2.Default) {
+						changes = append(changes, fmt.Sprintf("default: %v → %v", prop1.Default, prop2.Default))
+					}
+					if prop1.Dynamic != prop2.Dynamic {
+						changes = append(changes, fmt.Sprintf("dynamic: %v → %v", prop1.Dynamic, prop2.Dynamic))
+					}
+					if prop1.EnterpriseOnly != prop2.EnterpriseOnly {
+						changes = append(changes, fmt.Sprintf("enterprise-only: %v → %v", prop1.EnterpriseOnly, prop2.EnterpriseOnly))
+					}
+					if prop1.Deprecated != prop2.Deprecated {
+						changes = append(changes, fmt.Sprintf("deprecated: %v → %v", prop1.Deprecated, prop2.Deprecated))
+					}
+					if len(changes) > 0 {
+						diff += fmt.Sprintf(" (%s)", strings.Join(changes, ", "))
+					}
+				}
+				diffs = append(diffs, diff+"\n")
+			}
+		}
+	}
+
+	// Add summary at the end
+	if len(diffs) > 0 {
+		diffs = append(diffs, fmt.Sprintf("\nSummary: %d added, %d removed, %d changed\n", added, removed, changed))
+	}
+
+	return diffs
+}

--- a/cmd/schema_diff_test.go
+++ b/cmd/schema_diff_test.go
@@ -1,0 +1,701 @@
+//go:build unit
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type runTestSchemaDiff struct {
+	flags       []string
+	arguments   []string
+	expectError bool
+}
+
+var testSchemaDiffArgs = []runTestSchemaDiff{
+	{
+		flags:       []string{},
+		arguments:   []string{},
+		expectError: true, // too few args
+	},
+	{
+		flags:       []string{},
+		arguments:   []string{"6.4.0"},
+		expectError: true, // too few args
+	},
+	{
+		flags:       []string{},
+		arguments:   []string{"6.4.0", "7.0.0"},
+		expectError: false, // valid
+	},
+	{
+		flags:       []string{},
+		arguments:   []string{"6.4.0", "7.0.0", "8.0.0"},
+		expectError: true, // too many args
+	},
+	{
+		flags:       []string{},
+		arguments:   []string{"invalid.version", "7.0.0"},
+		expectError: true, // invalid version1
+	},
+	{
+		flags:       []string{},
+		arguments:   []string{"6.4.0", "invalid.version"},
+		expectError: true, // invalid version2
+	},
+	{
+		flags:       []string{"--verbose"},
+		arguments:   []string{"6.4.0", "7.0.0"},
+		expectError: false, // valid with details
+	},
+	{
+		flags:       []string{"--show-deprecated"},
+		arguments:   []string{"6.4.0", "7.0.0"},
+		expectError: false, // valid with deprecated
+	},
+	{
+		flags:       []string{"--filter-path", "service"},
+		arguments:   []string{"6.4.0", "7.0.0"},
+		expectError: false, // valid with filter
+	},
+	{
+		flags:       []string{"-d", "-D", "-f", "namespaces"},
+		arguments:   []string{"6.4.0", "7.0.0"},
+		expectError: false, // valid with all flags
+	},
+}
+
+func TestRunESchemaDiff(t *testing.T) {
+	for i, test := range testSchemaDiffArgs {
+		t.Run(fmt.Sprintf("test_%d", i), func(t *testing.T) {
+			cmd := newSchemaDiffCmd()
+
+			// Set flags
+			for j := 0; j < len(test.flags); j++ {
+				if test.flags[j] == "--verbose" || test.flags[j] == "-v" {
+					cmd.Flags().Set("verbose", "true")
+				} else if test.flags[j] == "--show-deprecated" || test.flags[j] == "-D" {
+					cmd.Flags().Set("show-deprecated", "true")
+				} else if test.flags[j] == "--filter-path" || test.flags[j] == "-f" {
+					if j+1 < len(test.flags) {
+						cmd.Flags().Set("filter-path", test.flags[j+1])
+						j++ // skip next flag as it's the value
+					}
+				}
+			}
+
+			// Execute command
+			err := cmd.RunE(cmd, test.arguments)
+
+			if test.expectError && err == nil {
+				t.Errorf("Expected error but got none")
+			} else if !test.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestExtractConfigProperties(t *testing.T) {
+	testSchema := map[string]interface{}{
+		"properties": map[string]interface{}{
+			"service": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"cluster-name": map[string]interface{}{
+						"type":        "string",
+						"default":     "",
+						"description": "Name of the cluster",
+						"dynamic":     true,
+					},
+					"auto-pin": map[string]interface{}{
+						"type":    "string",
+						"default": "none",
+						"enum":    []interface{}{"none", "cpu", "numa", "adq"},
+					},
+				},
+			},
+			"namespaces": map[string]interface{}{
+				"type": "array",
+				"items": map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"name": map[string]interface{}{
+							"type":        "string",
+							"description": "Namespace name",
+						},
+						"storage-engine": map[string]interface{}{
+							"type": "object",
+							"properties": map[string]interface{}{
+								"type": map[string]interface{}{
+									"type":    "string",
+									"default": "memory",
+									"enum":    []interface{}{"memory", "device"},
+								},
+								"devices": map[string]interface{}{
+									"type": "array",
+									"items": map[string]interface{}{
+										"type": "string",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	props := extractConfigProperties(testSchema)
+
+	// Check that service properties are extracted
+	if _, exists := props["service"]; !exists {
+		t.Error("Expected 'service' property to be extracted")
+	}
+
+	if _, exists := props["service.cluster-name"]; !exists {
+		t.Error("Expected 'service.cluster-name' property to be extracted")
+	}
+
+	if _, exists := props["service.auto-pin"]; !exists {
+		t.Error("Expected 'service.auto-pin' property to be extracted")
+	}
+
+	if _, exists := props["namespaces"]; !exists {
+		t.Error("Expected 'namespaces' property to be extracted")
+	}
+
+	// Check that namespace items properties are extracted
+	if _, exists := props["namespaces.items.name"]; !exists {
+		t.Error("Expected 'namespaces.items.name' property to be extracted")
+	}
+
+	if _, exists := props["namespaces.items.storage-engine"]; !exists {
+		t.Error("Expected 'namespaces.items.storage-engine' property to be extracted")
+	}
+
+	if _, exists := props["namespaces.items.storage-engine.type"]; !exists {
+		t.Error("Expected 'namespaces.items.storage-engine.type' property to be extracted")
+	}
+
+	if _, exists := props["namespaces.items.storage-engine.devices"]; !exists {
+		t.Error("Expected 'namespaces.items.storage-engine.devices' property to be extracted")
+	}
+
+	// Check property details
+	clusterName := props["service.cluster-name"]
+	if clusterName.Type != "string" {
+		t.Errorf("Expected cluster-name type to be 'string', got '%s'", clusterName.Type)
+	}
+
+	if clusterName.Default != "" {
+		t.Errorf("Expected cluster-name default to be empty string, got '%v'", clusterName.Default)
+	}
+
+	if !clusterName.Dynamic {
+		t.Error("Expected cluster-name to be dynamic")
+	}
+
+	autoPin := props["service.auto-pin"]
+	if len(autoPin.Enum) != 4 {
+		t.Errorf("Expected auto-pin to have 4 enum values, got %d", len(autoPin.Enum))
+	}
+
+	// Check namespace items properties
+	namespaceName := props["namespaces.items.name"]
+	if namespaceName.Type != "string" {
+		t.Errorf("Expected namespace name type to be 'string', got '%s'", namespaceName.Type)
+	}
+
+	storageEngineType := props["namespaces.items.storage-engine.type"]
+	if storageEngineType.Type != "string" {
+		t.Errorf("Expected storage-engine type to be 'string', got '%s'", storageEngineType.Type)
+	}
+
+	if storageEngineType.Default != "memory" {
+		t.Errorf("Expected storage-engine type default to be 'memory', got '%v'", storageEngineType.Default)
+	}
+}
+
+func TestExtractConfigPropertiesWithComplexArrays(t *testing.T) {
+	// Test with more complex nested structure similar to real Aerospike schema
+	testSchema := map[string]interface{}{
+		"properties": map[string]interface{}{
+			"namespaces": map[string]interface{}{
+				"type": "array",
+				"items": map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"storage-engine": map[string]interface{}{
+							"oneOf": []interface{}{
+								map[string]interface{}{
+									"type": "object",
+									"properties": map[string]interface{}{
+										"type": map[string]interface{}{
+											"type":    "string",
+											"default": "memory",
+											"enum":    []interface{}{"memory"},
+										},
+									},
+								},
+								map[string]interface{}{
+									"type": "object",
+									"properties": map[string]interface{}{
+										"type": map[string]interface{}{
+											"type":    "string",
+											"default": "device",
+											"enum":    []interface{}{"device"},
+										},
+										"devices": map[string]interface{}{
+											"type": "array",
+											"items": map[string]interface{}{
+												"type": "string",
+											},
+										},
+										"filesize": map[string]interface{}{
+											"type":    "integer",
+											"default": 0,
+											"minimum": 1048576,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	props := extractConfigProperties(testSchema)
+
+	// Check that oneOf structures are handled
+	if _, exists := props["namespaces.items.storage-engine"]; !exists {
+		t.Error("Expected 'namespaces.items.storage-engine' property to be extracted")
+	}
+
+	// Check that oneOf nested properties are extracted
+	if _, exists := props["namespaces.items.storage-engine.oneOf.0.type"]; !exists {
+		t.Error("Expected 'namespaces.items.storage-engine.oneOf.0.type' property to be extracted")
+	}
+
+	if _, exists := props["namespaces.items.storage-engine.oneOf.1.type"]; !exists {
+		t.Error("Expected 'namespaces.items.storage-engine.oneOf.1.type' property to be extracted")
+	}
+
+	if _, exists := props["namespaces.items.storage-engine.oneOf.1.devices"]; !exists {
+		t.Error("Expected 'namespaces.items.storage-engine.oneOf.1.devices' property to be extracted")
+	}
+
+	if _, exists := props["namespaces.items.storage-engine.oneOf.1.filesize"]; !exists {
+		t.Error("Expected 'namespaces.items.storage-engine.oneOf.1.filesize' property to be extracted")
+	}
+}
+
+func TestExtractConfigPropertiesEdgeCases(t *testing.T) {
+	// Test edge cases
+	testCases := []struct {
+		name   string
+		schema map[string]interface{}
+		check  func(map[string]PropertyInfo) bool
+	}{
+		{
+			name:   "empty schema",
+			schema: map[string]interface{}{},
+			check: func(props map[string]PropertyInfo) bool {
+				return len(props) == 0
+			},
+		},
+		{
+			name: "schema without properties",
+			schema: map[string]interface{}{
+				"type": "object",
+			},
+			check: func(props map[string]PropertyInfo) bool {
+				return len(props) == 0
+			},
+		},
+		{
+			name: "schema with non-object properties",
+			schema: map[string]interface{}{
+				"properties": "not an object",
+			},
+			check: func(props map[string]PropertyInfo) bool {
+				return len(props) == 0
+			},
+		},
+		{
+			name: "deeply nested structure",
+			schema: map[string]interface{}{
+				"properties": map[string]interface{}{
+					"level1": map[string]interface{}{
+						"type": "object",
+						"properties": map[string]interface{}{
+							"level2": map[string]interface{}{
+								"type": "object",
+								"properties": map[string]interface{}{
+									"level3": map[string]interface{}{
+										"type":    "string",
+										"default": "deep",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			check: func(props map[string]PropertyInfo) bool {
+				_, exists := props["level1.level2.level3"]
+				return exists
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			props := extractConfigProperties(tc.schema)
+			if !tc.check(props) {
+				t.Errorf("Test case '%s' failed", tc.name)
+			}
+		})
+	}
+}
+
+func TestCompareSchemasDetailed(t *testing.T) {
+	props1 := map[string]PropertyInfo{
+		"service.cluster-name": {
+			Type:    "string",
+			Default: "",
+			Dynamic: true,
+		},
+		"service.removed-prop": {
+			Type:    "boolean",
+			Default: false,
+		},
+		"service.changed-prop": {
+			Type:    "integer",
+			Default: 10,
+		},
+		"namespaces.items.name": {
+			Type:    "string",
+			Default: "",
+		},
+		"namespaces.items.storage-engine.type": {
+			Type:    "string",
+			Default: "memory",
+			Enum:    []interface{}{"memory", "device"},
+		},
+	}
+
+	props2 := map[string]PropertyInfo{
+		"service.cluster-name": {
+			Type:    "string",
+			Default: "",
+			Dynamic: true,
+		},
+		"service.new-prop": {
+			Type:    "string",
+			Default: "new",
+		},
+		"service.changed-prop": {
+			Type:    "integer",
+			Default: 20, // Changed default value
+		},
+		"namespaces.items.name": {
+			Type:    "string",
+			Default: "",
+		},
+		"namespaces.items.storage-engine.type": {
+			Type:    "string",
+			Default: "device", // Changed default
+			Enum:    []interface{}{"memory", "device"},
+		},
+		"namespaces.items.new-namespace-prop": {
+			Type:    "boolean",
+			Default: false,
+		},
+	}
+
+	diffs := compareSchemasDetailed(props1, props2, false, false, "")
+
+	if len(diffs) == 0 {
+		t.Error("Expected differences to be found")
+	}
+
+	// Check that we have the expected changes
+	diffText := strings.Join(diffs, "")
+
+	if !strings.Contains(diffText, "+ service.new-prop") {
+		t.Error("Expected to find added property 'service.new-prop'")
+	}
+
+	if !strings.Contains(diffText, "- service.removed-prop") {
+		t.Error("Expected to find removed property 'service.removed-prop'")
+	}
+
+	if !strings.Contains(diffText, "~ service.changed-prop") {
+		t.Error("Expected to find changed property 'service.changed-prop'")
+	}
+
+	if !strings.Contains(diffText, "+ namespaces.items.new-namespace-prop") {
+		t.Error("Expected to find added namespace property 'namespaces.items.new-namespace-prop'")
+	}
+
+	if !strings.Contains(diffText, "~ namespaces.items.storage-engine.type") {
+		t.Error("Expected to find changed namespace property 'namespaces.items.storage-engine.type'")
+	}
+
+	// Test with filter
+	filteredDiffs := compareSchemasDetailed(props1, props2, false, false, "service.cluster")
+	filteredText := strings.Join(filteredDiffs, "")
+
+	if strings.Contains(filteredText, "service.new-prop") {
+		t.Error("Expected filtered results to not contain 'service.new-prop'")
+	}
+
+	// Test with namespace filter
+	namespaceDiffs := compareSchemasDetailed(props1, props2, false, false, "namespaces")
+	namespaceText := strings.Join(namespaceDiffs, "")
+
+	if !strings.Contains(namespaceText, "namespaces.items.new-namespace-prop") {
+		t.Error("Expected namespace filtered results to contain 'namespaces.items.new-namespace-prop'")
+	}
+
+	if strings.Contains(namespaceText, "service.new-prop") {
+		t.Error("Expected namespace filtered results to not contain 'service.new-prop'")
+	}
+}
+
+func TestCompareSchemasDetailedWithDetailedOutput(t *testing.T) {
+	props1 := map[string]PropertyInfo{
+		"service.debug-allocations": {
+			Type:    "string",
+			Default: "none",
+			Enum:    []interface{}{"none", "transient", "persistent", "all"},
+		},
+		"service.feature-key-file": {
+			Type:    "string",
+			Default: "/opt/aerospike/data/features.conf",
+		},
+	}
+
+	props2 := map[string]PropertyInfo{
+		"service.debug-allocations": {
+			Type:    "boolean",
+			Default: false,
+		},
+		"service.feature-key-file": {
+			Type:           "string",
+			Default:        "/etc/aerospike/features.conf",
+			EnterpriseOnly: true,
+		},
+	}
+
+	diffs := compareSchemasDetailed(props1, props2, true, false, "")
+	diffText := strings.Join(diffs, "")
+
+	// Check that detailed output includes type changes
+	if !strings.Contains(diffText, "type: string → boolean") {
+		t.Error("Expected detailed output to show type change")
+	}
+
+	// Check that detailed output includes default changes
+	if !strings.Contains(diffText, "default: none → false") {
+		t.Error("Expected detailed output to show default change")
+	}
+
+	if !strings.Contains(diffText, "default: /opt/aerospike/data/features.conf → /etc/aerospike/features.conf") {
+		t.Error("Expected detailed output to show default path change")
+	}
+
+	// Check that detailed output includes enterprise-only changes
+	if !strings.Contains(diffText, "enterprise-only: false → true") {
+		t.Error("Expected detailed output to show enterprise-only change")
+	}
+}
+
+func TestCompareSchemasDetailedWithDeprecated(t *testing.T) {
+	props1 := map[string]PropertyInfo{
+		"service.old-prop": {
+			Type:       "string",
+			Default:    "old",
+			Deprecated: true,
+		},
+		"service.normal-prop": {
+			Type:    "string",
+			Default: "normal",
+		},
+	}
+
+	props2 := map[string]PropertyInfo{
+		"service.normal-prop": {
+			Type:    "string",
+			Default: "normal",
+		},
+		"service.new-prop": {
+			Type:       "string",
+			Default:    "new",
+			Deprecated: true,
+		},
+	}
+
+	// Test without showing deprecated
+	diffs := compareSchemasDetailed(props1, props2, false, false, "")
+	diffText := strings.Join(diffs, "")
+
+	if strings.Contains(diffText, "service.old-prop") {
+		t.Error("Expected deprecated properties to be hidden by default")
+	}
+
+	if strings.Contains(diffText, "service.new-prop") {
+		t.Error("Expected deprecated properties to be hidden by default")
+	}
+
+	// Test with showing deprecated
+	diffs = compareSchemasDetailed(props1, props2, false, true, "")
+	diffText = strings.Join(diffs, "")
+
+	if !strings.Contains(diffText, "- service.old-prop") {
+		t.Error("Expected deprecated removed properties to be shown when flag is set")
+	}
+
+	if !strings.Contains(diffText, "+ service.new-prop") {
+		t.Error("Expected deprecated added properties to be shown when flag is set")
+	}
+}
+
+func TestRealWorldSchemaComparison(t *testing.T) {
+	// Test with actual schema structure similar to what we have in the real files
+	schema1 := map[string]interface{}{
+		"properties": map[string]interface{}{
+			"service": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"cluster-name": map[string]interface{}{
+						"type":    "string",
+						"default": "",
+					},
+				},
+			},
+			"namespaces": map[string]interface{}{
+				"type": "array",
+				"items": map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"name": map[string]interface{}{
+							"type": "string",
+						},
+						"storage-engine": map[string]interface{}{
+							"oneOf": []interface{}{
+								map[string]interface{}{
+									"type": "object",
+									"properties": map[string]interface{}{
+										"type": map[string]interface{}{
+											"type":    "string",
+											"default": "memory",
+											"enum":    []interface{}{"memory"},
+										},
+									},
+								},
+								map[string]interface{}{
+									"type": "object",
+									"properties": map[string]interface{}{
+										"type": map[string]interface{}{
+											"type":    "string",
+											"default": "device",
+											"enum":    []interface{}{"device"},
+										},
+										"devices": map[string]interface{}{
+											"type": "array",
+											"items": map[string]interface{}{
+												"type": "string",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	schema2 := map[string]interface{}{
+		"properties": map[string]interface{}{
+			"service": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"cluster-name": map[string]interface{}{
+						"type":    "string",
+						"default": "",
+					},
+				},
+			},
+			"namespaces": map[string]interface{}{
+				"type": "array",
+				"items": map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"name": map[string]interface{}{
+							"type": "string",
+						},
+						"storage-engine": map[string]interface{}{
+							"oneOf": []interface{}{
+								map[string]interface{}{
+									"type": "object",
+									"properties": map[string]interface{}{
+										"type": map[string]interface{}{
+											"type":    "string",
+											"default": "memory",
+											"enum":    []interface{}{"memory"},
+										},
+									},
+								},
+								map[string]interface{}{
+									"type": "object",
+									"properties": map[string]interface{}{
+										"type": map[string]interface{}{
+											"type":    "string",
+											"default": "device",
+											"enum":    []interface{}{"device"},
+										},
+										"devices": map[string]interface{}{
+											"type": "array",
+											"items": map[string]interface{}{
+												"type": "string",
+											},
+										},
+										"filesize": map[string]interface{}{
+											"type":    "integer",
+											"default": 0,
+											"minimum": 1048576,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	props1 := extractConfigProperties(schema1)
+	props2 := extractConfigProperties(schema2)
+
+	diffs := compareSchemasDetailed(props1, props2, false, false, "namespaces")
+
+	if len(diffs) == 0 {
+		t.Error("Expected to find differences in namespace storage-engine")
+	}
+
+	diffText := strings.Join(diffs, "")
+
+	// Should detect the addition of filesize property
+	if !strings.Contains(diffText, "filesize") {
+		t.Error("Expected to find filesize property addition in namespace storage-engine")
+	}
+}


### PR DESCRIPTION
Implements `schema-diff` to compare Aerospike configuration schemas between two versions and `list-schemas` to list available schema versions. Includes comprehensive property extraction for arrays and oneOf structures, improved error handling, and extensive unit tests for command workflows and edge cases.