### PR TITLE
chore: TOOLS-3144 Update macOS versions in CI workflow

### DIFF
--- a/.github/workflows/mac-artifact.yml
+++ b/.github/workflows/mac-artifact.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     strategy:
       matrix: 
-        os: [macos-13, macos-14, macos-15]
+        os: [macos-14, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Get checkout directory


### PR DESCRIPTION
Removed macOS 13 from the build matrix in the GitHub Actions workflow for mac-artifact.yml, streamlining the CI process to focus on macOS 14 and 15.