### PR TITLE
feat: TOOLS-3291 Add Aerospike Server 8.1.2 configuration support

### DIFF
--- a/testdata/cases/server811/conf-tests.json
+++ b/testdata/cases/server811/conf-tests.json
@@ -3,10 +3,9 @@
         "Source":"testdata/cases/server811/server811.conf",
         "Destination":"testdata/cases/server811/server811-res-.yaml",
         "Expected":"testdata/cases/server811/server811.yaml",
-        "Arguments":["convert","--aerospike-version","8.1.1.0-rc20","--format","asconfig","--output","testdata/cases/server811/server811-res-.yaml"],
+        "Arguments":["convert","--aerospike-version","8.1.1.1","--format","asconfig","--output","testdata/cases/server811/server811-res-.yaml"],
         "SkipServerTest":false,
         "ServerErrorAllowList":null,
-        "ServerImage":"aerospike/aerospike-server-enterprise-rc:8.1.1.0-rc20",
-        "DockerAuth":{"Username":"ASC_DOCKER_USER","Password":"ASC_DOCKER_PASS"}
+        "ServerImage":"aerospike/aerospike-server-enterprise:8.1.1.1"
     }
 ]

--- a/testdata/cases/server811/versions.json
+++ b/testdata/cases/server811/versions.json
@@ -1,1 +1,1 @@
-{"TestedVersion":"8.1.1.0-rc20","OriginallyUsedVersion":"8.1.1.0-rc20"}
+{"TestedVersion":"8.1.1.1","OriginallyUsedVersion":"8.1.1.1"}

--- a/testdata/cases/server811/yaml-tests.json
+++ b/testdata/cases/server811/yaml-tests.json
@@ -3,10 +3,9 @@
         "Source":"testdata/cases/server811/server811.yaml",
         "Destination":"testdata/cases/server811/server811-res-.conf",
         "Expected":"testdata/cases/server811/server811.conf",
-        "Arguments":["convert","--aerospike-version","8.1.1.0-rc20","--format","yaml","--output","testdata/cases/server811/server811-res-.conf"],
+        "Arguments":["convert","--aerospike-version","8.1.1.1","--format","yaml","--output","testdata/cases/server811/server811-res-.conf"],
         "SkipServerTest":false,
         "ServerErrorAllowList":null,
-        "ServerImage":"aerospike/aerospike-server-enterprise-rc:8.1.1.0-rc20",
-        "DockerAuth":{"Username":"ASC_DOCKER_USER","Password":"ASC_DOCKER_PASS"}
+        "ServerImage":"aerospike/aerospike-server-enterprise:8.1.1.1"
     }
 ]

--- a/testdata/cases/server812/conf-tests.json
+++ b/testdata/cases/server812/conf-tests.json
@@ -1,0 +1,12 @@
+[
+    {
+        "Source":"testdata/cases/server812/server812.conf",
+        "Destination":"testdata/cases/server812/server812-res-.yaml",
+        "Expected":"testdata/cases/server812/server812.yaml",
+        "Arguments":["convert","--aerospike-version","8.1.2.0-20260327044720","--format","asconfig","--output","testdata/cases/server812/server812-res-.yaml"],
+        "SkipServerTest":false,
+        "ServerErrorAllowList":null,
+        "ServerImage":"artifact.aerospike.io/database-docker-dev-local/aerospike-server-enterprise:8.1.2.0-20260327044720",
+        "DockerAuth":{"Username":"ASC_DOCKER_USER","Password":"ASC_DOCKER_PASS"}
+    }
+]

--- a/testdata/cases/server812/conf-tests.json
+++ b/testdata/cases/server812/conf-tests.json
@@ -3,10 +3,9 @@
         "Source":"testdata/cases/server812/server812.conf",
         "Destination":"testdata/cases/server812/server812-res-.yaml",
         "Expected":"testdata/cases/server812/server812.yaml",
-        "Arguments":["convert","--aerospike-version","8.1.2.0-20260327044720","--format","asconfig","--output","testdata/cases/server812/server812-res-.yaml"],
+        "Arguments":["convert","--aerospike-version","8.1.2.0","--format","asconfig","--output","testdata/cases/server812/server812-res-.yaml"],
         "SkipServerTest":false,
         "ServerErrorAllowList":null,
-        "ServerImage":"artifact.aerospike.io/database-docker-dev-local/aerospike-server-enterprise:8.1.2.0-20260327044720",
-        "DockerAuth":{"Username":"ASC_DOCKER_USER","Password":"ASC_DOCKER_PASS"}
+        "ServerImage":"artifact.aerospike.io/database-docker-preview-public-local/aerospike-server-enterprise:8.1.2.0"
     }
 ]

--- a/testdata/cases/server812/server812.conf
+++ b/testdata/cases/server812/server812.conf
@@ -1,0 +1,115 @@
+
+service {
+    cluster-name cl1
+
+	user root
+	group root
+	pidfile /dummy/file/path1
+
+	batch-max-requests 1000
+	tls-refresh-period 300S
+	cgroup-mem-tracking true
+}
+
+logging {
+	console {
+		context namespace info
+		context masking info
+	}
+}
+
+network {
+	service {
+		address any
+		port 3000
+	}
+
+	heartbeat {
+		mode multicast
+		multicast-group 127.0.0.1
+		port 9918
+
+
+
+
+		interval 150
+		timeout 10
+	}
+
+	fabric {
+		port 3001
+	}
+
+	admin {
+		address any
+		port 3003
+	}
+}
+
+namespace ns1 {
+	replication-factor 2
+
+	index-type shmem
+	sindex-type shmem
+
+	disable-mrt-writes false
+	mrt-duration 60
+	strong-consistency true
+	apply-ttl-reductions false
+
+	migrate-skip-unreadable false
+	tomb-raider-unmark-threads 4
+
+	default-read-touch-ttl-pct 50
+
+	storage-engine memory {
+		data-size 32G
+    	}
+
+	evict-indexes-memory-pct 50
+
+	indexes-memory-budget 2147483648
+
+	nsup-period 2048
+
+	set s1 {
+		default-read-touch-ttl-pct -1
+	}
+
+	active-rack 2
+}
+
+namespace ns2 {
+	replication-factor 2
+	index-type shmem
+	sindex-type shmem
+	apply-ttl-reductions true
+	default-read-touch-ttl-pct 0
+	storage-engine device {
+        	device /dummy/mount/point1
+        	evict-used-pct 70
+        	stop-writes-used-pct 70
+        	stop-writes-avail-pct 20
+		flush-size 2M
+    	}
+
+	set s2 {
+		default-read-touch-ttl-pct 50
+	}
+}
+
+security {
+	default-password-file /dummy/file/path2
+}
+
+xdr {
+	dc dataCenter1 {
+		node-address-port 127.0.0.1 3000
+		recovery-threads 4
+		namespace ns1 {
+			remote-namespace ns2
+			ship-versions-interval 2M
+			ship-versions-policy interval
+		}
+	}
+}

--- a/testdata/cases/server812/server812.yaml
+++ b/testdata/cases/server812/server812.yaml
@@ -1,0 +1,86 @@
+logging:
+    - namespace: info
+      masking: info
+      name: console
+namespaces:
+    - default-read-touch-ttl-pct: 0
+      index-type:
+        type: shmem
+      name: ns2
+      replication-factor: 2
+      apply-ttl-reductions: true
+      sets:
+        - default-read-touch-ttl-pct: 50
+          name: s2
+      sindex-type:
+        type: shmem
+      storage-engine:
+        devices:
+            - /dummy/mount/point1
+        evict-used-pct: 70
+        flush-size: 2097152
+        stop-writes-avail-pct: 20
+        stop-writes-used-pct: 70
+        type: device
+    - active-rack: 2
+      default-read-touch-ttl-pct: 50
+      evict-indexes-memory-pct: 50
+      index-type:
+        type: shmem
+      indexes-memory-budget: 2147483648
+      name: ns1
+      nsup-period: 2048
+      replication-factor: 2
+      disable-mrt-writes: false
+      mrt-duration: 60
+      strong-consistency: true
+      apply-ttl-reductions: false
+      migrate-skip-unreadable: false
+      tomb-raider-unmark-threads: 4
+      sets:
+        - default-read-touch-ttl-pct: -1
+          name: s1
+      sindex-type:
+        type: shmem
+      storage-engine:
+        data-size: 34359738368
+        type: memory
+network:
+    fabric:
+        port: 3001
+    heartbeat:
+        interval: 150
+        mode: multicast
+        multicast-groups:
+            - 127.0.0.1
+        port: 9918
+        timeout: 10
+    admin:
+        addresses:
+            - any
+        port: 3003
+    service:
+        addresses:
+            - any
+        port: 3000
+security:
+    default-password-file: /dummy/file/path2
+service:
+    batch-max-requests: 1000
+    cgroup-mem-tracking: true
+    cluster-name: cl1
+    group: root
+    pidfile: /dummy/file/path1
+    tls-refresh-period: 300
+    user: root
+xdr:
+    dcs:
+        - name: dataCenter1
+          recovery-threads: 4
+          namespaces:
+            - name: ns1
+              remote-namespace: ns2
+              ship-versions-interval: 120
+              ship-versions-policy: interval
+          node-address-ports:
+            - 127.0.0.1:3000

--- a/testdata/cases/server812/versions.json
+++ b/testdata/cases/server812/versions.json
@@ -1,1 +1,1 @@
-{"TestedVersion":"8.1.2.0-20260327044720","OriginallyUsedVersion":"8.1.2.0-20260327044720"}
+{"TestedVersion":"8.1.2.0","OriginallyUsedVersion":"8.1.2.0"}

--- a/testdata/cases/server812/versions.json
+++ b/testdata/cases/server812/versions.json
@@ -1,0 +1,1 @@
+{"TestedVersion":"8.1.2.0-20260327044720","OriginallyUsedVersion":"8.1.2.0-20260327044720"}

--- a/testdata/cases/server812/yaml-tests.json
+++ b/testdata/cases/server812/yaml-tests.json
@@ -1,0 +1,12 @@
+[
+    {
+        "Source":"testdata/cases/server812/server812.yaml",
+        "Destination":"testdata/cases/server812/server812-res-.conf",
+        "Expected":"testdata/cases/server812/server812.conf",
+        "Arguments":["convert","--aerospike-version","8.1.2.0-20260327044720","--format","yaml","--output","testdata/cases/server812/server812-res-.conf"],
+        "SkipServerTest":false,
+        "ServerErrorAllowList":null,
+        "ServerImage":"artifact.aerospike.io/database-docker-dev-local/aerospike-server-enterprise:8.1.2.0-20260327044720",
+        "DockerAuth":{"Username":"ASC_DOCKER_USER","Password":"ASC_DOCKER_PASS"}
+    }
+]

--- a/testdata/cases/server812/yaml-tests.json
+++ b/testdata/cases/server812/yaml-tests.json
@@ -3,10 +3,9 @@
         "Source":"testdata/cases/server812/server812.yaml",
         "Destination":"testdata/cases/server812/server812-res-.conf",
         "Expected":"testdata/cases/server812/server812.conf",
-        "Arguments":["convert","--aerospike-version","8.1.2.0-20260327044720","--format","yaml","--output","testdata/cases/server812/server812-res-.conf"],
+        "Arguments":["convert","--aerospike-version","8.1.2.0","--format","yaml","--output","testdata/cases/server812/server812-res-.conf"],
         "SkipServerTest":false,
         "ServerErrorAllowList":null,
-        "ServerImage":"artifact.aerospike.io/database-docker-dev-local/aerospike-server-enterprise:8.1.2.0-20260327044720",
-        "DockerAuth":{"Username":"ASC_DOCKER_USER","Password":"ASC_DOCKER_PASS"}
+        "ServerImage":"artifact.aerospike.io/database-docker-preview-public-local/aerospike-server-enterprise:8.1.2.0"
     }
 ]


### PR DESCRIPTION
## Summary
- Update the schemas submodule to include the new Aerospike 8.1.2 JSON schema
- Add `server812` test case exercising the two new 8.1.2 config options:
  `cgroup-mem-tracking` (service) and `tomb-raider-unmark-threads` (namespace)
- Update `server811` test case to use the publicly released 8.1.1.1 image
  (previously pointed at RC)
## Changes
- **schema/schemas**: Bumped submodule to include `8.1.2.json`
- **testdata/cases/server812/**: New test case with `.conf`, `.yaml`,
  `versions.json`, `conf-tests.json`, and `yaml-tests.json`
- **testdata/cases/server811/**: Updated version from `8.1.1.0-rc20` to
  `8.1.1.1` and switched to the public Docker Hub image