### PR TITLE
fix(ci): align embedded binary version with PKG_VERSION

### DIFF
--- a/.github/bin/build_package.sh
+++ b/.github/bin/build_package.sh
@@ -12,14 +12,16 @@ function build_packages(){
   fi
   GIT_DIR=$(git rev-parse --show-toplevel)
 
+  # Version embedded in the binary must match the package version (CI passes PKG_VERSION).
+  # Export before `make` so the root Makefile's VERSION is used for -ldflags.
+  VERSION=${PKG_VERSION:-$(git describe --tags --always --abbrev=9)}
+  export VERSION
+  echo "build_package.sh version: ${VERSION}"
+
   # build
   cd "$GIT_DIR" || exit 1
   make clean
   make
-
-  echo "build_package.sh version: $(git describe --tags --always --abbrev=9)"
-  VERSION=${PKG_VERSION:-$(git describe --tags --always --abbrev=9)}
-  export VERSION
 
   # package
   cd $GIT_DIR/pkg || exit 1

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 # Variables required for this Makefile
 ROOT_DIR = $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-VERSION = $(shell git describe --tags --always --abbrev=9)
+# Honor VERSION from the environment (CI sets PKG_VERSION → build_package.sh exports VERSION)
+# so the linker-injected semver matches the packaged artifact version. Local builds keep the
+# git-describe default when VERSION is unset.
+VERSION ?= $(shell git describe --tags --always --abbrev=9)
 GO_ENV_VARS =
 INSTALL_DIR = /usr/local/bin
 TESTDATA_DIR = $(ROOT_DIR)/testdata


### PR DESCRIPTION
## Summary

- The root `Makefile` used `VERSION = $(git describe ...)`, which overrides the environment, so CI’s `PKG_VERSION` / exported `VERSION` never reached the `go build` `-ldflags` when `build_package.sh` ran `make`.
- `build_package.sh` now exports `VERSION` (from `PKG_VERSION` when set) **before** `make`, and the Makefile uses `VERSION ?=` so the linker-injected `cmd.VERSION` matches the `.deb` / Docker image the workflow expects.
- This fixes the Docker smoke step that runs `asconfig --version | grep -qF` against the semver prefix derived from the workflow `VERSION` (e.g. run 26461018190 failing with `ERROR: expected 0.20.1 in --version output`).

## Test plan

- [ ] Merge and run **Build and Release** (or the workflow that builds packages + Docker) on this branch or after merge to `main`.
- [ ] Confirm **Docker build, test & push** passes the **Build (native) and smoke test** step on both `amd64` and `arm64`.
- [ ] Spot-check `asconfig --version` inside the built image contains the same `MAJOR.MINOR.PATCH` as the workflow `VERSION` string.