### PR TITLE
TOOLS-3557 -  add Ubuntu 26.04 to release and installer build-check

### DIFF
--- a/.github/bin/install_deps.sh
+++ b/.github/bin/install_deps.sh
@@ -128,6 +128,26 @@ function install_deps_ubuntu24.04() {
   rm -rf /var/lib/apt/lists/*
 }
 
+function install_deps_ubuntu26.04() {
+  rm -rf /var/lib/apt/lists/*
+  apt-get clean
+  apt-get update -o Acquire::Retries=5
+  apt-get install -y --no-install-recommends ruby-rubygems make rpm git curl binutils build-essential ruby-dev libssl-dev
+
+  if [ "$(uname -m)" = "x86_64" ]; then
+      curl -L "${CURL_RETRY_OPTS[@]}" https://go.dev/dl/go"$GOLANG_VERSION".linux-amd64.tar.gz -o /tmp/go"$GOLANG_VERSION".linux-amd64.tar.gz
+      mkdir -p /opt/golang && tar -zxvf /tmp/go"$GOLANG_VERSION".linux-amd64.tar.gz -C /opt/golang
+  elif [ "$(uname -m)" = "aarch64" ]; then
+      curl -L "${CURL_RETRY_OPTS[@]}" https://go.dev/dl/go"$GOLANG_VERSION".linux-arm64.tar.gz -o /tmp/go"$GOLANG_VERSION".linux-arm64.tar.gz
+      mkdir -p /opt/golang && tar -zxvf /tmp/go"$GOLANG_VERSION".linux-arm64.tar.gz -C /opt/golang
+  else
+      echo "unknown arch $(uname -m)"
+      exit 1
+  fi
+  gem install fpm -v "$FPM_VERSION"
+  rm -rf /var/lib/apt/lists/*
+}
+
 function install_deps_el8() {
   dnf clean all
   dnf -y update

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -155,6 +155,7 @@ jobs:
           - ubuntu20.04
           - ubuntu22.04
           - ubuntu24.04
+          - ubuntu26.04
     runs-on: ${{ matrix.host }}
     container: >-
       ${{ matrix.distro == 'el8' && 'redhat/ubi8:8.10' ||
@@ -166,7 +167,8 @@ jobs:
         matrix.distro == 'debian13' && 'debian:trixie-20251020' ||
         matrix.distro == 'ubuntu20.04' && 'ubuntu:focal-20210723' ||
         matrix.distro == 'ubuntu22.04' && 'ubuntu:jammy-20231004' ||
-        matrix.distro == 'ubuntu24.04' && 'ubuntu:noble-20251013' }}
+        matrix.distro == 'ubuntu24.04' && 'ubuntu:noble-20251013' ||
+        matrix.distro == 'ubuntu26.04' && 'ubuntu:resolute-20260413' }}
     permissions:
       contents: read
     steps:
@@ -378,6 +380,7 @@ jobs:
           - ubuntu20.04
           - ubuntu22.04
           - ubuntu24.04
+          - ubuntu26.04
     runs-on: ${{ matrix.host }}
     container: >-
       ${{ matrix.distro == 'el8' && 'redhat/ubi8:8.10' ||
@@ -389,7 +392,8 @@ jobs:
         matrix.distro == 'debian13' && 'debian:trixie-20251020' ||
         matrix.distro == 'ubuntu20.04' && 'ubuntu:focal-20210723' ||
         matrix.distro == 'ubuntu22.04' && 'ubuntu:jammy-20231004' ||
-        matrix.distro == 'ubuntu24.04' && 'ubuntu:noble-20251013' }}
+        matrix.distro == 'ubuntu24.04' && 'ubuntu:noble-20251013' ||
+        matrix.distro == 'ubuntu26.04' && 'ubuntu:resolute-20260413' }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,7 +1,7 @@
 # Lightweight installer build check.
 #
 # Purpose: catch dependency / packaging regressions on every push, before
-# they reach the full release pipeline. The release workflow builds for 10
+# they reach the full release pipeline. The release workflow builds for 11
 # distros × 2 arches + signing + notarization — too heavy for every commit.
 #
 # This workflow exercises both fpm code paths (deb on Ubuntu, rpm on EL) on
@@ -37,8 +37,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { distro: ubuntu24.04, container: 'ubuntu:noble-20251013', pkg: deb }
-          - { distro: el10,        container: 'redhat/ubi10:10.0',    pkg: rpm }
+          - { distro: ubuntu24.04, container: 'ubuntu:noble-20251013',    pkg: deb }
+          - { distro: ubuntu26.04, container: 'ubuntu:resolute-20260413', pkg: deb }
+          - { distro: el10,        container: 'redhat/ubi10:10.0',       pkg: rpm }
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0


### PR DESCRIPTION
## Summary
- Add `ubuntu26.04` to the **Build and Release** matrix for both package build and Linux install/smoke-test jobs, using **`ubuntu:resolute-20260413`** as the build container (26.04 / resolute, pinned like other Ubuntu images).
- Extend **Build check (installer)** with a matching deb leg and update the header count (10 → 11 distros in the full release matrix).
- Implement **`install_deps_ubuntu26.04`** in `.github/bin/install_deps.sh`, aligned with the existing Ubuntu 24.04 toolchain (Ruby, fpm, Go).

## Test plan
- [ ] **Build check (installer)** workflow passes for `ubuntu26.04` (and existing matrix rows).
- [ ] **Build and Release** dry-run (or branch run) completes `build-artifacts` and **Test install & execute** for `ubuntu26.04` on amd64 and arm64 hosts.
- [ ] Confirm produced `.deb` filenames include `_ubuntu26.04_` and the test job finds the matching artifact.