### PR TITLE
ci: build and test Docker images on dry-run, push only on release

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -558,7 +558,6 @@ jobs:
 
   docker-build-arch:
     name: Docker build, test & push (${{ matrix.arch }})
-    if: inputs.release == true
     needs: [get-version, organize-signed-artifacts]
     strategy:
       fail-fast: false
@@ -592,6 +591,7 @@ jobs:
         run: npm install -g snyk@1.1304.3
 
       - name: Install JFrog CLI
+        if: inputs.release == true
         id: jf
         uses: step-security/setup-jfrog-cli@893a92f96c7727242adf0e603c77b1f2a22390e1 # v4.9.1
         env:
@@ -603,6 +603,7 @@ jobs:
           oidc-audience: database-gh-aerospike
 
       - name: Docker login to Artifactory
+        if: inputs.release == true
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: artifact.aerospike.io
@@ -645,6 +646,7 @@ jobs:
           fi
 
       - name: Push native per-arch tag to JFrog
+        if: inputs.release == true
         env:
           VERSION: ${{ needs.get-version.outputs.VERSION }}
         run: |
@@ -657,6 +659,7 @@ jobs:
 
   docker-manifest:
     name: Docker multi-arch manifest (stitch native tags)
+    if: inputs.release == true
     needs: [get-version, docker-build-arch]
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
## Summary

Both `asconfig` and `aerospike-benchmark` already had their `build-and-release.yml` aligned with the aerospike-admin/aql/aerospike-tools-backup pattern (VERSION file, `release`/`skip_tagging` inputs, tag-last, dry-run mode). The one remaining gap was the Docker build gate.

- Removes the job-level `if: inputs.release == true` from `docker-build-arch` so Docker images are **always** built and smoke-tested, even on dry-run dispatches
- Moves the publish gate to the three push-only steps: **Install JFrog CLI**, **Docker login to Artifactory**, **Push native per-arch tag to JFrog**
- Adds `if: inputs.release == true` to `docker-manifest` (pure push operation)

## Behaviour after this change

| Step | `release=false` (dry-run) | `release=true` (publish) |
|---|---|---|
| Docker build + smoke test | ✅ now runs | ✅ |
| JFrog login / push per-arch tag | ❌ skipped | ✅ |
| Docker multi-arch manifest | ❌ skipped | ✅ |

## Test plan
- [ ] Dispatch with `release=false` and confirm `docker-build-arch` runs build/test steps but skips JFrog login and push
- [ ] Dispatch with `release=true` and confirm full publish flow is unchanged