### PR TITLE
ci(pkg): dynamic-dependency allowlist guard

### DIFF
--- a/.github/bin/build_package.sh
+++ b/.github/bin/build_package.sh
@@ -1,6 +1,23 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
+function assert_dynamic_deps() {
+  local allowed="libc.so.6 libm.so.6 libpthread.so.0 libdl.so.2 librt.so.1
+    libresolv.so.2 ld-linux-x86-64.so.2 ld-linux-aarch64.so.1"
+
+  local lib fail=0
+  local needed
+  needed=$(readelf -d "$GIT_DIR/bin/asconfig" | awk '/\(NEEDED\)/ { gsub(/[][]/, "", $NF); print $NF }')
+  echo "asconfig DT_NEEDED:" $needed
+  for lib in $needed; do
+    if ! printf '%s\n' $allowed | grep -qxF "$lib"; then
+      echo "asconfig has unexpected dynamic dependency $lib; link it statically or add it to the allowlist and the package depends" >&2
+      fail=1
+    fi
+  done
+  return $fail
+}
+
 function build_packages(){
   if [ "${ENV_DISTRO:-}" = "" ]; then
     echo "ENV_DISTRO is not set"
@@ -22,6 +39,8 @@ function build_packages(){
   cd "$GIT_DIR" || exit 1
   make clean
   make
+
+  assert_dynamic_deps
 
   # package
   cd $GIT_DIR/pkg || exit 1


### PR DESCRIPTION
## Problem

asconfig is built with cgo enabled (`CGO_ENABLED` unset, C toolchain present on all build containers), so the shipped Linux binary is dynamically linked against glibc. fpm with dir input emits no deb Depends and sets `AutoReqProv: no` for rpm, so packages declare nothing, and nothing stops a new dynamic dependency from silently appearing undeclared. Same hardening as aerospike/aql#84, aerospike/aerospike-tools-backup#164, aerospike/aerospike-benchmark#155.

## Changes

- **.github/bin/build_package.sh**: `assert_dynamic_deps` gate between build and packaging. Dumps `DT_NEEDED` of `bin/asconfig` and fails on anything outside the glibc family (libc/libm/libpthread/libdl/librt/libresolv + loader). Runs in every job of both build-and-release and the PR-time build-check.

Today's binary needs only glibc, which is present on every target by definition, so no package metadata changes are needed. The guard pins that state.

## Verification

Dry-run Build and Release dispatch on this branch (release=false) exercises the guard across the full 10-distro × 2-arch matrix; results posted below.