### PR TITLE
fix(pkg): add -1 release iteration to deb/rpm package names

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -438,7 +438,7 @@ jobs:
           case "${{ matrix.distro }}" in
             ubuntu*|debian*)
               export DEBIAN_FRONTEND=noninteractive
-              pkg=$(find ./packages -name "*_${{ matrix.distro }}_*${arch}*.deb" | head -1)
+              pkg=$(find ./packages -name "*${{ matrix.distro }}_*${arch}*.deb" | head -1)
               [[ -n "${pkg}" ]] || { echo "ERROR: no .deb found for ${{ matrix.distro }}/${arch}" >&2; exit 1; }
               apt-get install -y "${pkg}"
               ;;

--- a/docker/docker-build.sh
+++ b/docker/docker-build.sh
@@ -377,8 +377,8 @@ function generate_bake() {
 #   LOCAL_PKGS_COPIED           (paths to clean up on EXIT)
 # ---------------------------------------------------------------------------
 function resolve_packages() {
-  local pkg_amd64="aerospike-asconfig_${VERSION}-1_ubuntu24.04_x86_64.deb"
-  local pkg_arm64="aerospike-asconfig_${VERSION}-1_ubuntu24.04_aarch64.deb"
+  local pkg_amd64="aerospike-asconfig_${VERSION}-1ubuntu24.04_x86_64.deb"
+  local pkg_arm64="aerospike-asconfig_${VERSION}-1ubuntu24.04_aarch64.deb"
   local pool="${DEB_BASE_URL}/pool/${UBUNTU_CODENAME}/aerospike-asconfig"
 
   ASCONFIG_AMD64_URL="${pool}/${pkg_amd64}"

--- a/docker/docker-build.sh
+++ b/docker/docker-build.sh
@@ -377,8 +377,8 @@ function generate_bake() {
 #   LOCAL_PKGS_COPIED           (paths to clean up on EXIT)
 # ---------------------------------------------------------------------------
 function resolve_packages() {
-  local pkg_amd64="aerospike-asconfig_${VERSION}_ubuntu24.04_x86_64.deb"
-  local pkg_arm64="aerospike-asconfig_${VERSION}_ubuntu24.04_aarch64.deb"
+  local pkg_amd64="aerospike-asconfig_${VERSION}-1_ubuntu24.04_x86_64.deb"
+  local pkg_arm64="aerospike-asconfig_${VERSION}-1_ubuntu24.04_aarch64.deb"
   local pool="${DEB_BASE_URL}/pool/${UBUNTU_CODENAME}/aerospike-asconfig"
 
   ASCONFIG_AMD64_URL="${pool}/${pkg_amd64}"

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -12,6 +12,8 @@ NAME = "aerospike-asconfig"
 MAINTAINER = "Aerospike"
 VERSION ?= $(shell git describe --tags --always --abbrev=9)
 RPM_VERSION := $(subst -,_,$(VERSION))
+# rpm Release / deb revision: the "-1" after the version in package names.
+ITERATION ?= 1
 # pkgbuild --version rejects hyphens and underscores; collapse both to dots
 # so SemVer pre-release tags (e.g. 0.20.1-rc1 -> 0.20.1.rc1) are accepted, and
 # defensively normalize any underscore-form inputs (env overrides) too.
@@ -38,12 +40,13 @@ deb: prep
 		--chdir $(BUILD_DIR)/ \
 		--name $(NAME) \
 		--version $(VERSION) \
+		--iteration $(ITERATION) \
 		--maintainer $(MAINTAINER) \
 		--description $(DESCRIPTION) \
 		--license $(LICENSE) \
 		--url $(URL) \
 		--vendor $(VENDOR) \
-		--package $(TARGET_DIR)/$(NAME)_$(VERSION)_$(BUILD_DISTRO)_$(ARCH).deb
+		--package $(TARGET_DIR)/$(NAME)_$(VERSION)-$(ITERATION)_$(BUILD_DISTRO)_$(ARCH).deb
 
 .PHONY: rpm
 rpm: prep
@@ -54,12 +57,13 @@ rpm: prep
 		--chdir $(BUILD_DIR)/ \
 		--name $(NAME) \
 		--version $(RPM_VERSION) \
+		--iteration $(ITERATION) \
 		--maintainer $(MAINTAINER) \
 		--description $(DESCRIPTION) \
 		--license $(LICENSE) \
 		--url $(URL) \
 		--vendor $(VENDOR) \
-		--package $(TARGET_DIR)/$(NAME)-$(RPM_VERSION).$(BUILD_DISTRO).$(ARCH).rpm
+		--package $(TARGET_DIR)/$(NAME)-$(RPM_VERSION)-$(ITERATION).$(BUILD_DISTRO).$(ARCH).rpm
 
 .PHONY: tar
 tar: prep

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -12,8 +12,10 @@ NAME = "aerospike-asconfig"
 MAINTAINER = "Aerospike"
 VERSION ?= $(shell git describe --tags --always --abbrev=9)
 RPM_VERSION := $(subst -,_,$(VERSION))
-# rpm Release / deb revision: the "-1" after the version in package names.
+# rpm Release / deb revision. The deb revision embeds the distro per Debian
+# convention (e.g. 5.0.3-1debian12), like the rpm dist tag.
 ITERATION ?= 1
+DEB_ITERATION = $(ITERATION)$(BUILD_DISTRO)
 # pkgbuild --version rejects hyphens and underscores; collapse both to dots
 # so SemVer pre-release tags (e.g. 0.20.1-rc1 -> 0.20.1.rc1) are accepted, and
 # defensively normalize any underscore-form inputs (env overrides) too.
@@ -40,13 +42,13 @@ deb: prep
 		--chdir $(BUILD_DIR)/ \
 		--name $(NAME) \
 		--version $(VERSION) \
-		--iteration $(ITERATION) \
+		--iteration $(DEB_ITERATION) \
 		--maintainer $(MAINTAINER) \
 		--description $(DESCRIPTION) \
 		--license $(LICENSE) \
 		--url $(URL) \
 		--vendor $(VENDOR) \
-		--package $(TARGET_DIR)/$(NAME)_$(VERSION)-$(ITERATION)_$(BUILD_DISTRO)_$(ARCH).deb
+		--package $(TARGET_DIR)/$(NAME)_$(VERSION)-$(DEB_ITERATION)_$(ARCH).deb
 
 .PHONY: rpm
 rpm: prep


### PR DESCRIPTION
## What

Adds a package release iteration (`-1`) after the version in .deb/.rpm artifact names, matching the server convention (`aerospike-server-community-8.1.3.0-66.amzn2023.aarch64.rpm`).

| Artifact | Before | After |
|---|---|---|
| rpm | `aerospike-asconfig-0.21.2.el8.x86_64.rpm` | `aerospike-asconfig-0.21.2-1.el8.x86_64.rpm` |
| deb | `aerospike-asconfig_0.21.2_ubuntu24.04_x86_64.deb` | `aerospike-asconfig_0.21.2-1_ubuntu24.04_x86_64.deb` |

## How

- `pkg/Makefile`: new `ITERATION ?= 1`, passed to fpm as `--iteration` and appended in the `--package` filenames.
- rpm: metadata already carried `Release: 1` (fpm default), so only the filename changes.
- deb: control `Version` becomes `0.21.2-1` (proper Debian revision, sorts above the bare `0.21.2`).
- `docker/docker-build.sh`: the released deb it resolves by name gains the `-1`.
- tar and macOS .pkg names are unchanged (no revision concept there).

## Verification

- `make -n` dry runs expand to `aerospike-asconfig_X.Y.Z-1_<distro>_<arch>.deb` and `aerospike-asconfig-X.Y.Z-1.<distro>.<arch>.rpm`; rc versions expand to `X.Y.Z-rc1-1` (deb) / `X.Y.Z_rc1-1` (rpm).
- CI test-install globs (`*_<distro>_*<arch>*.deb`, `*.<distro>.*<arch>*.rpm`) already match the new names, no workflow change needed.

## Coordination

The aerospike-tools bundle downloads per-tool packages from JFrog by name; its companion PR updates those globs with a fallback so bundle builds work with tool versions released before or after this change. Bundle picks up the new names once a release is cut from this branch's repo.
